### PR TITLE
Add User Settings configuration to the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dmypy.json
 
 # private things
 config.yml
+user-settings.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
         additional_dependencies:
           - types-flask
           - types-requests
+          - types-PyYAML
         args:
           - --strict
           - --ignore-missing-imports

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -2,8 +2,10 @@ from flask import Blueprint
 from flask_restx import Api
 
 from api.authentication import api as auth
+from api.user_settings import api as user_settings
 
 blueprint = Blueprint("api", __name__, url_prefix="/api/v1")
-api = Api(blueprint, title="MarkTrader API", version="1.0", doc="/doc/")
+api = Api(blueprint, title="MarkTrader API", version="1.0", doc="/doc/", validate=True)
 
 api.add_namespace(auth)
+api.add_namespace(user_settings)

--- a/api/user_settings.py
+++ b/api/user_settings.py
@@ -1,6 +1,9 @@
 import typing as t
+from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, fields, inputs, reqparse
+from flask import request
+from flask_restx import Namespace, Resource, fields
+from pydantic import ValidationError
 from werkzeug.exceptions import UnprocessableEntity
 
 from config import UserSettings
@@ -9,73 +12,31 @@ from services.authentication import AuthenticationService
 api = Namespace("userSettings", description="Access and update user settings")
 
 user_settings_response = api.model(
-    "User settings",
+    "UserSettings",
     {
         "symbols": fields.List(
             fields.String(),
-            required=True,
             description="List of Stock Symbols to use in the application",
         ),
         "endOfDayExit": fields.Boolean(
-            required=True,
             attribute="end_of_day_exit",
             description="Whether or not to exit all positions at the end of the day",
         ),
         "enableAutomatedTrading": fields.Boolean(
-            required=True,
             attribute="enable_automated_trading",
             description="Whether or not the application should run automated trades",
         ),
         "tradingFrequencySeconds": fields.Integer(
             min=1,
-            required=True,
             attribute="trading_frequency_seconds",
             description="How frequently to run the automated trading loop",
         ),
         "positionSize": fields.Float(
             exclusiveMin=0,
-            required=True,
             attribute="position_size",
             description="Size of order to buy",
         ),
     },
-)
-
-user_settings_request = reqparse.RequestParser()
-user_settings_request.add_argument(
-    "symbols",
-    type=list,
-    location="json",
-    help="Stock symbols the application should access. If supplied, this list "
-    "will replace the existing symbols. An empty list will remove all symbols.",
-)
-user_settings_request.add_argument(
-    "endOfDayExit",
-    type=inputs.boolean,
-    location="json",
-    dest="end_of_day_exit",
-    help="If supplied, updates whether or not to exit positions at the end of the day",
-)
-user_settings_request.add_argument(
-    "enableAutomatedTrading",
-    type=inputs.boolean,
-    location="json",
-    dest="enable_automated_trading",
-    help="If supplied, updates whether or not automated trading should be enabled",
-)
-user_settings_request.add_argument(
-    "tradingFrequencySeconds",
-    type=int,
-    location="json",
-    dest="trading_frequency_seconds",
-    help="If supplied, updates the automated trader's frequency",
-)
-user_settings_request.add_argument(
-    "positionSize",
-    type=float,
-    location="json",
-    dest="position_size",
-    help="If supplied, updates the dollar value to buy an option",
 )
 
 
@@ -84,39 +45,37 @@ class UserSettingsResource(Resource):
     @api.doc("Get User Settings")
     @api.marshal_with(user_settings_response)
     def get(self) -> t.Dict[str, t.Union[int, float, bool, t.List[str]]]:
-        return UserSettings()
+        return t.cast(
+            t.Dict[str, t.Union[int, float, bool, t.List[str]]], UserSettings().dict()
+        )
 
     @api.doc("Update User Settings")
-    def patch(self) -> None:
-        args = user_settings_request.parse_args()
+    @api.expect(user_settings_response)
+    def patch(
+        self,
+    ) -> t.Union[
+        t.Dict[str, t.Union[int, float, bool, t.List[str]]],
+        t.Tuple[HTTPStatus, t.List[t.Dict[str, t.Any]]],
+    ]:
+        args = request.get_json()
         auth_service = AuthenticationService()
         user_settings = UserSettings()
 
         symbols = args.get("symbols")
-        end_of_day_exit = args.get("end_of_day_exit")
         enable_automated_trading = args.get("enable_automated_trading")
-        trading_frequency_seconds = args.get("trading_frequency_seconds")
-        position_size = args.get("position_size")
 
         if symbols is not None:
-            user_settings.symbols = [s.upper() for s in symbols]
-        if end_of_day_exit is not None:
-            user_settings.end_of_day_exit = end_of_day_exit
+            args["symbols"] = [s.upper() for s in symbols]
         if enable_automated_trading is not None:
             if enable_automated_trading and not auth_service.active_tokens:
                 raise UnprocessableEntity(
                     "Cannot enable automated trading. Application does not have an active brokerage"
                 )
-            user_settings.enable_automated_trading = enable_automated_trading
-        if trading_frequency_seconds is not None:
-            if trading_frequency_seconds < 1:
-                raise UnprocessableEntity(
-                    "tradingFrequencySeconds must be greater than or equal to 1"
-                )
-            user_settings.trading_frequency_seconds = trading_frequency_seconds
-        if position_size is not None:
-            if position_size <= 0:
-                raise UnprocessableEntity("positionSize must be greater than 0")
-            user_settings.position_size = position_size
 
-        user_settings.save()
+        try:
+            user_settings.update(args)
+        except ValidationError as e:
+            return HTTPStatus.UNPROCESSABLE_ENTITY, e.errors()
+        return t.cast(
+            t.Dict[str, t.Union[int, float, bool, t.List[str]]], UserSettings().dict()
+        )

--- a/api/user_settings.py
+++ b/api/user_settings.py
@@ -1,6 +1,5 @@
 import re
 import typing as t
-from http import HTTPStatus
 
 from flask import request
 from flask_restx import Namespace, Resource, fields
@@ -53,12 +52,19 @@ class UserSettingsResource(Resource):
 
     @api.doc("Update User Settings")
     @api.expect(user_settings_response)
+    @api.marshal_with(user_settings_response)
     def patch(
         self,
     ) -> tuple[int, dict[str, ErrorList]] | dict[str, int | float | bool | list[str]]:
         args = request.get_json()
         auth_service = AuthenticationService()
         user_settings = UserSettings()
+
+        # convert camel to snake
+        args = {
+            re.sub(r"(?<!^)(?=[A-Z])", "_", key).lower(): val
+            for key, val in args.items()
+        }
 
         enable_automated_trading = args.get("enable_automated_trading")
 
@@ -68,15 +74,10 @@ class UserSettingsResource(Resource):
                     "Cannot enable automated trading. Application does not have an active brokerage"
                 )
 
-        # convert camel to snake
-        args = {
-            re.sub(r"(?<!^)(?=[A-Z])", "_", key).lower(): val
-            for key, val in args.items()
-        }
         try:
             user_settings.update(args)
         except ValidationError as e:
-            return HTTPStatus.UNPROCESSABLE_ENTITY, {"errors": e.errors()}
+            raise UnprocessableEntity(e.errors())
         return t.cast(
             t.Dict[str, t.Union[int, float, bool, t.List[str]]], UserSettings().dict()
         )

--- a/api/user_settings.py
+++ b/api/user_settings.py
@@ -56,8 +56,8 @@ class UserSettingsResource(Resource):
     def patch(
         self,
     ) -> t.Union[
-        tuple[int, dict[str, ErrorList]],
-        dict[str, t.Union[int, float, bool, list[str]]],
+        t.Tuple[int, t.Dict[str, ErrorList]],
+        t.Dict[str, t.Union[int, float, bool, t.List[str]]],
     ]:
         args = request.get_json()
         auth_service = AuthenticationService()

--- a/api/user_settings.py
+++ b/api/user_settings.py
@@ -1,0 +1,122 @@
+import typing as t
+
+from flask_restx import Namespace, Resource, fields, inputs, reqparse
+from werkzeug.exceptions import UnprocessableEntity
+
+from config import UserSettings
+from services.authentication import AuthenticationService
+
+api = Namespace("userSettings", description="Access and update user settings")
+
+user_settings_response = api.model(
+    "User settings",
+    {
+        "symbols": fields.List(
+            fields.String(),
+            required=True,
+            description="List of Stock Symbols to use in the application",
+        ),
+        "endOfDayExit": fields.Boolean(
+            required=True,
+            attribute="end_of_day_exit",
+            description="Whether or not to exit all positions at the end of the day",
+        ),
+        "enableAutomatedTrading": fields.Boolean(
+            required=True,
+            attribute="enable_automated_trading",
+            description="Whether or not the application should run automated trades",
+        ),
+        "tradingFrequencySeconds": fields.Integer(
+            min=1,
+            required=True,
+            attribute="trading_frequency_seconds",
+            description="How frequently to run the automated trading loop",
+        ),
+        "positionSize": fields.Float(
+            exclusiveMin=0,
+            required=True,
+            attribute="position_size",
+            description="Size of order to buy",
+        ),
+    },
+)
+
+user_settings_request = reqparse.RequestParser()
+user_settings_request.add_argument(
+    "symbols",
+    type=list,
+    location="json",
+    help="Stock symbols the application should access. If supplied, this list "
+    "will replace the existing symbols. An empty list will remove all symbols.",
+)
+user_settings_request.add_argument(
+    "endOfDayExit",
+    type=inputs.boolean,
+    location="json",
+    dest="end_of_day_exit",
+    help="If supplied, updates whether or not to exit positions at the end of the day",
+)
+user_settings_request.add_argument(
+    "enableAutomatedTrading",
+    type=inputs.boolean,
+    location="json",
+    dest="enable_automated_trading",
+    help="If supplied, updates whether or not automated trading should be enabled",
+)
+user_settings_request.add_argument(
+    "tradingFrequencySeconds",
+    type=int,
+    location="json",
+    dest="trading_frequency_seconds",
+    help="If supplied, updates the automated trader's frequency",
+)
+user_settings_request.add_argument(
+    "positionSize",
+    type=float,
+    location="json",
+    dest="position_size",
+    help="If supplied, updates the dollar value to buy an option",
+)
+
+
+@api.route("/")
+class UserSettingsResource(Resource):
+    @api.doc("Get User Settings")
+    @api.marshal_with(user_settings_response)
+    def get(self) -> t.Dict[str, t.Union[int, float, bool, t.List[str]]]:
+        return UserSettings()
+
+    @api.doc("Update User Settings")
+    def patch(self) -> None:
+        args = user_settings_request.parse_args()
+        auth_service = AuthenticationService()
+        user_settings = UserSettings()
+
+        symbols = args.get("symbols")
+        end_of_day_exit = args.get("end_of_day_exit")
+        enable_automated_trading = args.get("enable_automated_trading")
+        trading_frequency_seconds = args.get("trading_frequency_seconds")
+        position_size = args.get("position_size")
+
+        if symbols is not None:
+            user_settings.symbols = [s.upper() for s in symbols]
+        if end_of_day_exit is not None:
+            user_settings.end_of_day_exit = end_of_day_exit
+        if enable_automated_trading is not None:
+            if enable_automated_trading and not auth_service.active_tokens:
+                raise UnprocessableEntity(
+                    "Cannot enable automated trading. Application does not have an active brokerage"
+                )
+            user_settings.enable_automated_trading = enable_automated_trading
+        if trading_frequency_seconds is not None:
+            if trading_frequency_seconds < 1:
+                raise UnprocessableEntity(
+                    "tradingFrequencySeconds must be greater than or equal to 1"
+                )
+            user_settings.trading_frequency_seconds = trading_frequency_seconds
+        if position_size is not None:
+            if position_size <= 0:
+                raise UnprocessableEntity("positionSize must be greater than 0")
+            user_settings.position_size = position_size
+
+        user_settings.save()

--- a/api/user_settings.py
+++ b/api/user_settings.py
@@ -55,7 +55,10 @@ class UserSettingsResource(Resource):
     @api.marshal_with(user_settings_response)
     def patch(
         self,
-    ) -> tuple[int, dict[str, ErrorList]] | dict[str, int | float | bool | list[str]]:
+    ) -> t.Union[
+        tuple[int, dict[str, ErrorList]],
+        dict[str, t.Union[int, float, bool, list[str]]],
+    ]:
         args = request.get_json()
         auth_service = AuthenticationService()
         user_settings = UserSettings()

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 import typing as t
 from pathlib import Path
 
+import yaml
 from confz import ConfZ, ConfZFileSource
 
 from common.enums import BrokerageId
@@ -36,3 +37,19 @@ class GlobalConfig(ConfZ):
     @property
     def brokerage_map(self) -> t.Dict[BrokerageId, BrokerageConfig]:
         return {b.id: b for b in self.brokerages}
+
+
+class UserSettings(ConfZ):
+    symbols: t.List[str]
+    end_of_day_exit: bool = True
+    enable_automated_trading: bool = False
+    trading_frequency_seconds: int = 5
+    position_size: float = 0
+
+    CONFIG_SOURCES = ConfZFileSource(file=Path("./user-settings.yml"))
+
+    @classmethod
+    def save(cls) -> None:
+        with open(cls.CONFIG_SOURCES.file, mode="w") as f:
+            yaml.dump(cls.confz_instance.dict(), f)
+            cls.confz_instance = None

--- a/test/backend/unit/api/conftest.py
+++ b/test/backend/unit/api/conftest.py
@@ -1,6 +1,12 @@
+import datetime
+
 import pytest
+from mock.mock import PropertyMock, patch
 
 from app import app
+from common.enums import BrokerageId
+from common.models import AuthTokens
+from services.authentication import AuthenticationService
 
 
 @pytest.fixture
@@ -17,3 +23,32 @@ def client(trader_app):
 @pytest.fixture
 def runner(trader_app):
     return trader_app.test_cli_runner()
+
+
+@pytest.fixture
+def tokens():
+    return AuthTokens(
+        BrokerageId.TD,
+        "access_token",
+        datetime.datetime.now() + datetime.timedelta(minutes=30),
+        "refresh_token",
+        datetime.datetime.now() + datetime.timedelta(days=30),
+    )
+
+
+@pytest.fixture
+def auth_service_signed_out():
+    with patch.object(
+        AuthenticationService, "active_tokens", new_callable=PropertyMock
+    ) as mock_tokens:
+        mock_tokens.return_value = None
+        yield
+
+
+@pytest.fixture
+def auth_service_signed_in(tokens):
+    with patch.object(
+        AuthenticationService, "active_tokens", new_callable=PropertyMock
+    ) as mock_tokens:
+        mock_tokens.return_value = tokens
+        yield

--- a/test/backend/unit/api/test_authentication.py
+++ b/test/backend/unit/api/test_authentication.py
@@ -8,8 +8,6 @@ from config import GlobalConfig
 from services.authentication import AuthenticationService
 from services.brokerage import get_brokerage_service
 
-# pytestmark = pytest.mark.usefixtures("global_config")
-
 
 def test_get_auth_url(client):
     config = GlobalConfig()

--- a/test/backend/unit/api/test_authentication.py
+++ b/test/backend/unit/api/test_authentication.py
@@ -1,9 +1,6 @@
-import datetime
+import pytest
+from mock.mock import patch
 
-from mock.mock import PropertyMock, patch
-
-from common.enums import BrokerageId
-from common.models import AuthTokens
 from config import GlobalConfig
 from services.authentication import AuthenticationService
 from services.brokerage import get_brokerage_service
@@ -25,38 +22,24 @@ def test_get_auth_url_not_found(client):
     assert "Brokerage ID other is not recognized" in response.json["message"]
 
 
-def test_get_auth_status_signed_in(client):
+@pytest.mark.usefixtures("auth_service_signed_in")
+def test_get_auth_status_signed_in(client, tokens):
     config = GlobalConfig()
-    tokens = AuthTokens(
-        BrokerageId.TD,
-        "access_token",
-        datetime.datetime.now() + datetime.timedelta(minutes=30),
-        "refresh_token",
-        datetime.datetime.now() + datetime.timedelta(days=30),
-    )
-    with patch.object(
-        AuthenticationService, "active_tokens", new_callable=PropertyMock
-    ) as mock_tokens:
-        mock_tokens.return_value = tokens
 
-        response = client.get("/api/v1/auth/")
-        assert response.status_code == 200
-        assert response.json["id"] == tokens.brokerage_id.value
-        assert response.json["name"] == config.brokerage_map[tokens.brokerage_id].name
-        assert response.json["signedIn"]
+    response = client.get("/api/v1/auth/")
+    assert response.status_code == 200
+    assert response.json["id"] == tokens.brokerage_id.value
+    assert response.json["name"] == config.brokerage_map[tokens.brokerage_id].name
+    assert response.json["signedIn"]
 
 
+@pytest.mark.usefixtures("auth_service_signed_out")
 def test_get_auth_status_signed_out(client):
-    with patch.object(
-        AuthenticationService, "active_tokens", new_callable=PropertyMock
-    ) as mock_tokens:
-        mock_tokens.return_value = None
-
-        response = client.get("/api/v1/auth/")
-        assert response.status_code == 200
-        assert not response.json["id"]
-        assert not response.json["name"]
-        assert not response.json["signedIn"]
+    response = client.get("/api/v1/auth/")
+    assert response.status_code == 200
+    assert not response.json["id"]
+    assert not response.json["name"]
+    assert not response.json["signedIn"]
 
 
 def test_sign_out(client):

--- a/test/backend/unit/api/test_authentication.py
+++ b/test/backend/unit/api/test_authentication.py
@@ -1,6 +1,5 @@
 import datetime
 
-import pytest
 from mock.mock import PropertyMock, patch
 
 from common.enums import BrokerageId
@@ -9,7 +8,7 @@ from config import GlobalConfig
 from services.authentication import AuthenticationService
 from services.brokerage import get_brokerage_service
 
-pytestmark = pytest.mark.usefixtures("global_config")
+# pytestmark = pytest.mark.usefixtures("global_config")
 
 
 def test_get_auth_url(client):

--- a/test/backend/unit/api/test_user_settings.py
+++ b/test/backend/unit/api/test_user_settings.py
@@ -1,17 +1,6 @@
 import pytest
-from mock.mock import PropertyMock, patch
 
 from config import UserSettings
-from services.authentication import AuthenticationService
-
-
-@pytest.fixture
-def auth_service_signed_out():
-    with patch.object(
-        AuthenticationService, "active_tokens", new_callable=PropertyMock
-    ) as mock_tokens:
-        mock_tokens.return_value = None
-        yield
 
 
 def to_camel_case(snake_str):
@@ -40,6 +29,7 @@ def test_get_user_settings(client, user_settings):
         ),
     ],
 )
+@pytest.mark.usefixtures("auth_service_signed_in")
 def test_patch_user_settings(client, user_settings_from_file, payload, expected_status):
     original_settings, _ = user_settings_from_file
     original_settings = original_settings.dict()

--- a/test/backend/unit/api/test_user_settings.py
+++ b/test/backend/unit/api/test_user_settings.py
@@ -49,7 +49,7 @@ def test_patch_user_settings(client, user_settings_from_file, payload, expected_
 
     response = client.patch("/api/v1/userSettings/", json=payload)
 
-    assert response.status_code == expected_status
+    assert response.status_code == expected_status, response.json
 
     if expected_status == 200:
         original_settings_camel.update(payload)

--- a/test/backend/unit/api/test_user_settings.py
+++ b/test/backend/unit/api/test_user_settings.py
@@ -1,0 +1,73 @@
+import pytest
+from mock.mock import PropertyMock, patch
+
+from config import UserSettings
+from services.authentication import AuthenticationService
+
+
+@pytest.fixture
+def auth_service_signed_out():
+    with patch.object(
+        AuthenticationService, "active_tokens", new_callable=PropertyMock
+    ) as mock_tokens:
+        mock_tokens.return_value = None
+        yield
+
+
+def to_camel_case(snake_str):
+    components = snake_str.split("_")
+    # We capitalize the first letter of each component except the first one
+    # with the 'title' method and join them together.
+    return components[0] + "".join(x.title() for x in components[1:])
+
+
+def test_get_user_settings(client, user_settings):
+    response = client.get("/api/v1/userSettings/")
+    assert response.status_code == 200
+    assert response.json == {
+        to_camel_case(k): v for k, v in user_settings.dict().items()
+    }
+
+
+@pytest.mark.parametrize(
+    "payload, expected_status",
+    [
+        pytest.param(
+            {"positionSize": 5, "enableAutomatedTrading": True}, 200, id="success"
+        ),
+        pytest.param(
+            {"positionSize": -5, "enableAutomatedTrading": True}, 422, id="fail"
+        ),
+    ],
+)
+def test_patch_user_settings(client, user_settings_from_file, payload, expected_status):
+    original_settings, _ = user_settings_from_file
+    original_settings = original_settings.dict()
+    original_settings_camel = {
+        to_camel_case(k): v for k, v in original_settings.items()
+    }
+
+    response = client.patch("/api/v1/userSettings/", json=payload)
+
+    assert response.status_code == expected_status
+
+    if expected_status == 200:
+        original_settings_camel.update(payload)
+        assert response.json == original_settings_camel
+    else:
+        assert UserSettings().dict() == original_settings
+
+
+@pytest.mark.usefixtures("auth_service_signed_out")
+def test_enable_trading_signed_out(client, user_settings_from_file):
+    original_settings, _ = user_settings_from_file
+    original_settings = original_settings.dict()
+
+    response = client.patch(
+        "/api/v1/userSettings/",
+        json={"positionSize": 5, "enableAutomatedTrading": True},
+    )
+
+    assert response.status_code == 422
+
+    assert UserSettings().dict() == original_settings

--- a/test/backend/unit/conftest.py
+++ b/test/backend/unit/conftest.py
@@ -1,7 +1,12 @@
-import pytest
-from confz import ConfZDataSource
+import typing as t
+from pathlib import Path
+from tempfile import NamedTemporaryFile
 
-from config import GlobalConfig
+import pytest
+import yaml
+from confz import ConfZDataSource, ConfZFileSource
+
+from config import GlobalConfig, UserSettings
 
 
 @pytest.fixture
@@ -20,8 +25,36 @@ def td_brokerage():
 
 
 @pytest.fixture
+def user_settings() -> UserSettings:
+    with UserSettings.change_config_sources(
+        ConfZDataSource(
+            data={
+                "enable_automated_trading": True,
+                "end_of_day_exit": True,
+                "position_size": 10.0,
+                "symbols": ["AMZN", "IBM"],
+                "trading_frequency_seconds": 1,
+            }
+        )
+    ):
+        yield UserSettings()
+
+
+@pytest.fixture(autouse=True)
 def global_config(server_config, td_brokerage):
     with GlobalConfig.change_config_sources(
         ConfZDataSource(data={"server": server_config, "brokerages": [td_brokerage]})
     ):
         yield
+
+
+# All tests should be forced to use these fixtures for their user settings and global config
+
+
+@pytest.fixture(autouse=True)
+def user_settings_from_file(user_settings) -> t.Tuple[UserSettings, str]:
+    with NamedTemporaryFile(mode="w", suffix=".yml") as tmp:
+        yaml.dump(user_settings.dict(), tmp)
+        tmp.flush()
+        with UserSettings.change_config_sources(ConfZFileSource(file=Path(tmp.name))):
+            yield UserSettings(), tmp.name

--- a/test/backend/unit/services/test_authentication.py
+++ b/test/backend/unit/services/test_authentication.py
@@ -10,8 +10,6 @@ from config import GlobalConfig
 from services.authentication import AuthenticationService, refresh_access
 from services.brokerage import TDAmeritradeBrokerageService
 
-# pytestmark = pytest.mark.usefixtures("global_config")
-
 
 @pytest.fixture
 def mock_start_daemon():

--- a/test/backend/unit/services/test_authentication.py
+++ b/test/backend/unit/services/test_authentication.py
@@ -10,7 +10,7 @@ from config import GlobalConfig
 from services.authentication import AuthenticationService, refresh_access
 from services.brokerage import TDAmeritradeBrokerageService
 
-pytestmark = pytest.mark.usefixtures("global_config")
+# pytestmark = pytest.mark.usefixtures("global_config")
 
 
 @pytest.fixture

--- a/test/backend/unit/services/test_authentication.py
+++ b/test/backend/unit/services/test_authentication.py
@@ -187,7 +187,6 @@ class TestRefreshAccess:
 
     def test_refresh_not_signed_in(self, auth_service_not_signed_in):
         auth_service = auth_service_not_signed_in
-        old_tokens = auth_service.active_tokens
         with mock.patch("services.authentication.safe_sleep") as mock_sleep, mock.patch(
             "services.brokerage.TDAmeritradeBrokerageService.refresh_tokens"
         ) as mock_refresh:

--- a/test/backend/unit/services/test_brokerage.py
+++ b/test/backend/unit/services/test_brokerage.py
@@ -9,7 +9,7 @@ from config import GlobalConfig
 from services.brokerage import TDAmeritradeBrokerageService
 
 
-@pytest.mark.usefixtures("global_config")
+# @pytest.mark.usefixtures("global_config")
 class TestTDAmeritradeBrokerageService:
     @pytest.fixture
     def old_tokens(self):

--- a/test/backend/unit/test_config.py
+++ b/test/backend/unit/test_config.py
@@ -1,0 +1,35 @@
+import pytest
+from pydantic import ValidationError
+
+from config import UserSettings
+
+
+class TestUserSettings:
+    def test_update_success(self, user_settings_from_file):
+        settings, path = user_settings_from_file
+        update_data = {"symbols": ["GE", "ibm", "ABC"], "end_of_day_exit": False}
+        original = settings.dict()
+        settings.update(update_data)
+        updated_dict = UserSettings().dict()
+
+        update_data["symbols"] = [s.upper() for s in update_data["symbols"]]
+        for key in updated_dict.keys():
+            if key in update_data:
+                assert updated_dict[key] == update_data[key]
+                update_data.pop(key)
+            else:
+                assert updated_dict[key] == original[key]
+            original.pop(key)
+
+        assert not original
+        assert not update_data
+
+    def test_update_fail(self, user_settings_from_file):
+        settings, path = user_settings_from_file
+        update_data = {"position_size": -1}
+        original = settings.dict()
+        with pytest.raises(ValidationError):
+            settings.update(update_data)
+        updated_dict = UserSettings().dict()
+
+        assert original == updated_dict


### PR DESCRIPTION
Create `UserSettings` configuration object to handle dynamic configuration
 - can be updated
 - updates overwrite values in config file
Add `/userSettings/` API routes
 - `GET` retrieve the current user settings
 - `PATCH` update user settings
   - validates values
   - cannot enable automated trading if there are not active tokens